### PR TITLE
CRITICAL FIX: fixing expo-device package crashing the app on Android 13

### DIFF
--- a/patches/expo-device+4.2.0.patch
+++ b/patches/expo-device+4.2.0.patch
@@ -1,0 +1,18 @@
+diff --git a/node_modules/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt b/node_modules/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
+index 0984d45..2af0c1e 100644
+--- a/node_modules/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
++++ b/node_modules/expo-device/android/src/main/java/expo/modules/device/DeviceModule.kt
+@@ -62,7 +62,12 @@ class DeviceModule(private val mContext: Context) : ExportedModule(mContext) {
+     "osInternalBuildId" to Build.ID,
+     "osBuildFingerprint" to Build.FINGERPRINT,
+     "platformApiLevel" to Build.VERSION.SDK_INT,
+-    "deviceName" to Settings.Secure.getString(mContext.contentResolver, "bluetooth_name")
++    "deviceName" to run {
++      if (Build.VERSION.SDK_INT <= 31)
++        Settings.Secure.getString(mContext.contentResolver, "bluetooth_name")
++      else
++        Settings.Global.getString(mContext.contentResolver, Settings.Global.DEVICE_NAME)
++    },
+   )
+ 
+   private val deviceYearClass: Int


### PR DESCRIPTION
Release Notes (Android): Fixing App Crashing at startup on Android 13 devices. 

the patch is referenced here: https://github.com/expo/expo/issues/18738
We will remove the patch after the we migrate to a newer version of expo