### PR TITLE
fix: clearing amount string of leading and trailing white space

### DIFF
--- a/app/fragments/secure/SimpleTransferFragment.tsx
+++ b/app/fragments/secure/SimpleTransferFragment.tsx
@@ -95,7 +95,7 @@ export const SimpleTransferFragment = fragment(() => {
         // Parse value
         let value: BN;
         try {
-            const validAmount = amount.replace(',', '.');
+            const validAmount = amount.replace(',', '.').trim();
             // Manage jettons with decimals
             if (jettonWallet) {
                 value = toBNWithDecimals(validAmount, jettonMaster?.decimals);


### PR DESCRIPTION
There was an issue with white spaces on Android devices, you could press space key while entering an amount