### PR TITLE
fix: fixing initial biometrics-state value

### DIFF
--- a/app/components/Item.tsx
+++ b/app/components/Item.tsx
@@ -43,6 +43,7 @@ export const ItemSwitch = memo((props: {
     leftIcon?: ImageSourcePropType,
     leftIconComponent?: any,
     titleStyle?: StyleProp<TextStyle>
+    disabled?: boolean,
 }) => {
     const theme = useTheme();
     return (
@@ -56,6 +57,7 @@ export const ItemSwitch = memo((props: {
                 flexDirection: 'row',
                 padding: 20,
             }}
+            disabled={props.disabled}
         >
             <View style={{ flexDirection: 'row', flexShrink: 1, alignItems: 'center' }}>
                 {props.leftIcon && (<Image style={{ height: 24, width: 24, marginRight: 13 }} source={props.leftIcon} />)}
@@ -87,6 +89,7 @@ export const ItemSwitch = memo((props: {
                 pointerEvents={'none'}
                 value={props.value}
                 onValueChange={props.onChange}
+                disabled={props.disabled}
             />
         </Pressable>
     )

--- a/app/components/secure/AuthWalletKeys.tsx
+++ b/app/components/secure/AuthWalletKeys.tsx
@@ -136,7 +136,7 @@ export const AuthWalletKeysContextProvider = memo((props: { children?: any }) =>
 
         const passcodeState = getPasscodeState();
         const biometricsState = getBiometricsState();
-        const useBiometrics = (biometricsState === BiometricsState.InUse);
+        const useBiometrics = (biometricsState === BiometricsState.InUse || biometricsState === null);
         const passcodeLength = storage.getNumber(passcodeLengthKey) ?? 6;
 
         // Try to authenticate with biometrics
@@ -145,6 +145,9 @@ export const AuthWalletKeysContextProvider = memo((props: { children?: any }) =>
             try {
                 const acc = getCurrentAddress();
                 const keys = await loadWalletKeys(acc.secretKeyEnc);
+                if (biometricsState === null) {
+                    setBiometricsState(BiometricsState.InUse);
+                }
                 return keys;
             } catch (e) {
                 if (e instanceof SecureAuthenticationCancelledError) {

--- a/app/engine/hooks/appstate/useBiometricsState.ts
+++ b/app/engine/hooks/appstate/useBiometricsState.ts
@@ -2,6 +2,6 @@ import { BiometricsState } from '../../../storage/secureStorage';
 import { biometricsState } from '../../state/biometricsAndPasscode';
 import { useRecoilValue } from 'recoil';
 
-export function useBiometricsState(): BiometricsState {
+export function useBiometricsState(): BiometricsState | null {
     return useRecoilValue(biometricsState);
 }

--- a/app/engine/state/biometricsAndPasscode.ts
+++ b/app/engine/state/biometricsAndPasscode.ts
@@ -1,12 +1,14 @@
 import { atom } from 'recoil';
-import { BiometricsState, PasscodeState, getBiometricsState, getPasscodeState, storeBiometricsState, storePasscodeState } from '../../storage/secureStorage';
+import { PasscodeState, getBiometricsState, getPasscodeState, storeBiometricsState, storePasscodeState } from '../../storage/secureStorage';
 
 export const biometricsState = atom({
     key: 'auth/biometricsState',
-    default:  (getBiometricsState() || BiometricsState.NotSet),
+    default:  getBiometricsState(),
     effects: [({ onSet }) => {
         onSet((newValue) => {
-            storeBiometricsState(newValue);
+            if (!!newValue) {
+                storeBiometricsState(newValue);
+            }
         })
     }]
 });

--- a/app/fragments/SecurityFragment.tsx
+++ b/app/fragments/SecurityFragment.tsx
@@ -81,7 +81,8 @@ export const SecurityFragment = fragment(() => {
 
     }, [deviceEncryption, passcodeState]);
 
-    const [biometricsToggleValue, setBiometricsToggleValue] = useState<boolean>(biometricsState === BiometricsState.InUse);
+    const useBiometrics = (biometricsState === BiometricsState.InUse || biometricsState === null);
+    const [biometricsToggleValue, setBiometricsToggleValue] = useState<boolean>(useBiometrics);
 
     useEffect(() => {
         const updateDeviceEncryption = () => {

--- a/app/fragments/SecurityFragment.tsx
+++ b/app/fragments/SecurityFragment.tsx
@@ -173,6 +173,8 @@ export const SecurityFragment = fragment(() => {
                                 <ItemSwitch
                                     title={biometricsProps.buttonText}
                                     value={biometricsToggleValue}
+                                    // we can't disable biometrics if passcode is not set
+                                    disabled={passcodeState !== PasscodeState.Set}
                                     leftIconComponent={deviceEncryption === 'face' ? undefined : biometricsProps.icon}
                                     leftIcon={deviceEncryption === 'face' ? require('@assets/ic-secure-face.png') : undefined}
                                     onChange={async (newValue: boolean) => {


### PR DESCRIPTION
- setting to inUse on loadWalletKeys success
- useBiometricsState now can return null
- disabling settings switch if passcode is not set