### PR TITLE
fix(android): keep Kotlin JVM-target validation at warning

### DIFF
--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -54,3 +54,9 @@ hermesEnabled=true
 android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
+
+# Kotlin 1.9 turned the JVM-target mismatch check into an error; third-party modules
+# (e.g. expo-modules-core's android-annotation: Java 11 + default Kotlin target from
+# the build JDK) don't align their targets, same as under Kotlin 1.8.10 where this
+# was never validated. Keep it a warning.
+kotlin.jvm.target.validation.mode=warning


### PR DESCRIPTION
Kotlin 1.9 (bumped for Intercom 15.x) escalated the JVM-target mismatch check to an error, failing the release build on expo-modules-core's android-annotation subproject (Java 11 + Kotlin defaulting to the build JDK's 17). Under Kotlin 1.8.10 this was never validated; the module is a compile-time annotation processor running on the host JDK, so the mismatch is harmless — downgrade the check back to a warning.