### PR TITLE
fix(android): override AGP's D8 with standalone R8 8.3.37

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -15,6 +15,11 @@ buildscript {
         mavenCentral()
     }
     dependencies {
+        // Newer standalone R8/D8: AGP 7.4.2's built-in D8 NPEs ("Error while dexing")
+        // on late-2024 androidx/intercom artifacts pulled in by intercom-sdk 15.14
+        // (fragment 1.8.5, constraintlayout 2.2.0, profileinstaller 1.4.0). Must be
+        // declared BEFORE the android gradle plugin to take precedence on the classpath.
+        classpath('com.android.tools:r8:8.3.37')
         classpath('com.android.tools.build:gradle:7.4.2')
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:${kotlinVersion}")
         classpath 'com.google.gms:google-services:4.3.15'


### PR DESCRIPTION
The intercom-sdk 15.14 unpin transitively upgrades androidx artifacts to late-2024 releases (fragment 1.8.5, constraintlayout 2.2.0, profileinstaller 1.4.0, error_prone_annotations 2.36.0) whose class files the built-in D8 of AGP 7.4.2 cannot dex (NullPointerException in DexingNoClasspathTransform). A newer standalone R8/D8 on the buildscript classpath handles them; a full AGP 8 migration is left for later.