### PR TITLE
fix(support,gram): coderabbit findings — memo deps and double bottom …

### DIFF
--- a/app/components/browser/BrowserConnections.tsx
+++ b/app/components/browser/BrowserConnections.tsx
@@ -164,7 +164,8 @@ export const BrowserConnections = memo(
             </View>
           ))}
         </View>
-        <View style={{ height: Platform.OS === 'android' ? 64 : safeArea.bottom }} />
+        {/* iOS bottom clearance comes from contentInset (safe bottom tab bar height) */}
+        <View style={{ height: Platform.OS === 'android' ? 64 : 0 }} />
       </Animated.ScrollView>
     );
   },

--- a/app/components/browser/BrowserExtensions.tsx
+++ b/app/components/browser/BrowserExtensions.tsx
@@ -159,7 +159,8 @@ export const BrowserExtensions = memo(({ onScroll }: { onScroll?: (event: Native
           />
         </View>
       ))}
-      <View style={{ height: bottomBarHeight + safeArea.top + safeArea.bottom + 256 }} />
+      {/* bottomBarHeight already includes the bottom safe-area inset */}
+      <View style={{ height: bottomBarHeight + safeArea.top + 256 }} />
     </Animated.ScrollView>
   );
 },

--- a/app/fragments/secure/simpleTransfer/components/SimpleTransferAmount.tsx
+++ b/app/fragments/secure/simpleTransfer/components/SimpleTransferAmount.tsx
@@ -190,7 +190,7 @@ export const SimpleTransferAmount = memo(forwardRef(({
                 </View>
             </Pressable>
         );
-    }, [onNavigateAssets, network.isTestnet, jetton, symbol, isSCAM, theme]);
+    }, [onNavigateAssets, network.isTestnet, jetton, symbol, displaySymbol, isSCAM, theme]);
 
     const _decimals = selectedAsset?.type === 'extraCurrency' ? extraCurrency?.preview?.decimals : decimals;
 
@@ -218,7 +218,7 @@ export const SimpleTransferAmount = memo(forwardRef(({
                 </Text>
             </Pressable>
         </View>
-    ), [balance, jetton?.decimals, jetton?.symbol, onAddAll, decimals, theme])
+    ), [balance, jetton?.decimals, jetton?.symbol, symbol, displaySymbol, onAddAll, decimals, theme])
 
     const onFocus = useCallback(() => onInputFocus(1), [])
 
@@ -242,7 +242,7 @@ export const SimpleTransferAmount = memo(forwardRef(({
             ticker={displaySymbol || NATIVE_DISPLAY_SYMBOL}
             cursorColor={theme.accent}
         />
-    ), [onInputFocus, onValueChange, amountError, priceText, symbol, amount, theme])
+    ), [onInputFocus, onValueChange, amountError, priceText, symbol, displaySymbol, amount, theme])
 
     const amountErrorLabel = useMemo(() => amountError && (
         <Animated.View


### PR DESCRIPTION
…insets

- SimpleTransferAmount: displaySymbol added to the assetButton/valueComponent/ amountInput memo deps (asset-switch could leave a stale GRAM/TON label)
- BrowserConnections/BrowserExtensions: drop the duplicated bottom safe-area contribution now that useSafeBottomTabBarHeight already returns it outside a tab navigator