### PR TITLE
fix(ios): stop committing .xcode.env.local with a hardcoded node path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ android/app/netmain
 android/app/nettest
 
 sentry.properties
+# Machine-specific node path for the RN build scripts — must not be committed
+ios/.xcode.env.local

--- a/ios/.xcode.env.local
+++ b/ios/.xcode.env.local
@@ -1,1 +1,0 @@
-export NODE_BINARY="/usr/local/bin/node"


### PR DESCRIPTION
## Why

Build 1911 on `develop` failed:

```
Node found at: /usr/local/bin/node
.../script_phases.sh: line 34: /usr/local/bin/node: No such file or directory
Command PhaseScriptExecution failed with a nonzero exit code
```

`ios/.xcode.env.local` is committed to the repo and pins `NODE_BINARY` to `/usr/local/bin/node` — the Intel-Homebrew location. Xcode Cloud's current image has node somewhere else, so every phase that shells out to node dies: `[CP-User] Generate Specs` (React-rncore), `[CP] Copy XCFrameworks` (hermes-engine, OpenSSL-Universal).

Older builds passed because the previous image did have node at that path — nothing in our code changed, the runner did.

## Fix

By React Native convention `.xcode.env.local` is machine-specific and is not version controlled; the committed `ios/.xcode.env` already does the right thing:

```sh
export NODE_BINARY=$(command -v node)
```

So the file is untracked here and added to `.gitignore`. Local copies stay on disk untouched — anyone who needs a custom node path keeps their own version.

Same breakage hits local builds on Apple Silicon: the hardcoded Intel path makes `Generate Specs` fail on a clean checkout, which is how this was originally found.

Verified there is no other hardcoded `/usr/local/bin/node` anywhere in the repo (Podfile, pbxproj, scripts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)