### PR TITLE
fix(ci): retry pod install so a transient GitHub 503 does not fail the build

### DIFF
--- a/ios/ci_scripts/ci_post_clone.sh
+++ b/ios/ci_scripts/ci_post_clone.sh
@@ -88,6 +88,19 @@ brew install yarn
 echo "===== Generating node_modules ====="
 yarn
 echo "===== Installing pods ====="
-PRODUCTION=1 pod install
+# Some pods are fetched straight from GitHub Releases (AppsFlyerFramework), which
+# intermittently answers 503 — under `set -e` that single hiccup kills the whole build.
+# Retry a couple of times before giving up.
+pod_attempt=1
+pod_max_attempts=3
+until PRODUCTION=1 pod install; do
+    if [ "$pod_attempt" -ge "$pod_max_attempts" ]; then
+        echo "===== pod install failed after $pod_max_attempts attempts ====="
+        exit 1
+    fi
+    echo "===== pod install failed (attempt $pod_attempt/$pod_max_attempts), retrying in 30s ====="
+    pod_attempt=$((pod_attempt + 1))
+    sleep 30
+done
 # the sed command from RN cant find the file... so we have to run it ourselves
 sed -i -e  $'s/ && (__IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_10_0)//' /Volumes/workspace/repository/ios/Pods/RCT-Folly/folly/portability/Time.h


### PR DESCRIPTION
## Why

The build after #1947 got past the node problem and then died in `ci_post_clone.sh`:

```
Installing AppsFlyerFramework (6.15.1)
[!] Error installing AppsFlyerFramework
curl: (56) The requested URL returned error: 503
Command exited with non-zero exit-code: 1
```

CocoaPods downloads AppsFlyerFramework straight from GitHub Releases. That URL answered 503 for a moment and, because the script runs under `set -e` with a single `pod install`, the whole Xcode Cloud run was lost before a single file was compiled. The same URL responds 200 again — nothing is actually broken, the dependency was momentarily unavailable.

## Fix

Retry `pod install` up to 3 times with a 30s pause, then fail exactly as before.

Verified: `sh -n` passes, and the loop was exercised on a fixture — two failures then success lets the script continue (`set -e` does not trip on the `until` condition), three failures exit 1.

Not a substitute for rerunning the current build — that one just needs a restart. This is so the next 503 costs a retry instead of a build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)